### PR TITLE
OpenCL: rename Z61 fma() to z61_fma() for AMD COMGR overload resolution

### DIFF
--- a/src/cl/math.cl
+++ b/src/cl/math.cl
@@ -820,7 +820,7 @@ Z61 OVERLOAD mul(Z61 a, Z61 b) {
   return add(lo61, hi61);
 }
 
-Z61 OVERLOAD fma(Z61 a, Z61 b, Z61 c) { return add(mul(a, b), c); }             // GWBUG:  Can we do better?
+Z61 OVERLOAD z61_fma(Z61 a, Z61 b, Z61 c) { return add(mul(a, b), c); }             // GWBUG:  Can we do better?  (Not named fma: clashes with float fma on some OpenCL compilers.)
 
 // Multiply by 2
 Z61 OVERLOAD mul2(Z61 a) { return ((a + a) + (a >> 60)) & M61; }        // GWBUG: Make sure "+ a>>60" does an add to lower u32 without a followup adc.
@@ -962,7 +962,7 @@ Z61 OVERLOAD weakMul(Z61 a, Z61 b, const u32 a_m61_count, const u32 b_m61_count)
 
 Z61 OVERLOAD mul(Z61 a, Z61 b) { return modM61(weakMul(a, b, 2, 2)); }
 
-Z61 OVERLOAD fma(Z61 a, Z61 b, Z61 c) { return modM61(weakMul(a, b, 2, 2) + c); }             // GWBUG:  Can we do better?
+Z61 OVERLOAD z61_fma(Z61 a, Z61 b, Z61 c) { return modM61(weakMul(a, b, 2, 2) + c); }             // GWBUG:  Can we do better?  (Not named fma: clashes with float fma on some OpenCL compilers.)
 
 // Multiply by 2
 Z61 OVERLOAD mul2(Z61 a) { return add(a, a); }


### PR DESCRIPTION
I got this error when running tune after building the project from your repo:
 In file included from C:\Users\jeffr\AppData\Local\Temp\comgr-49671b\input\CompileSource:1:
In file included from C:\Users\jeffr\AppData\Local\Temp\comgr-49671b\include\fftp.cl:7:
In file included from C:\Users\jeffr\AppData\Local\Temp\comgr-49671b\include\fftwidth.cl:4:
C:\Users\jeffr\AppData\Local\Temp\comgr-49671b\include\fftbase.cl:528:8: error: assigning to '__private F2' (aka '__private float2') from incompatible type 'ulong2' (vector of 2 'ulong' values)
  528 |   base = U2(fma(a, -w.y, w.x), fma(a, w.x, -w.y));
      |        ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

The below was obviously written by AI, so take it with a grain of salt for sure, but the changes compiled and it did allow me to get through a --tune cycle. I'm on windows with an AMD 7700 XT

~~~~~~~~~~~~~~~~~~~~~~~~
With NTT_GF61 enabled (e.g. FFT3261 / FFT323161), math.cl defined an overloadable fma taking three Z61 (ulong) arguments. On AMD COMGR, overload resolution for float/F calls such as U2(fma(a, -w.y, w.x), fma(a, w.x, -w.y)) could incorrectly select fma(Z61, Z61, Z61) via implicit conversions. That makes fma return ulong, U2 become ulong2, and assignment to F2/float2 fail at compile time.

Fix

Rename the Z61 helper to z61_fma in both definitions in math.cl (including the alternate path behind the older #if 0 block so naming stays consistent if that block is enabled). No call sites used fma with three Z61 values, so no other source changes were required.