### PR TITLE
Added CD workflow to build release executables

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,157 @@
+name: CD
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  Linux-OpenCL:
+    name: Linux OpenCL
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+    - name: Script
+      run: |
+        docker run --rm -i -v "$GITHUB_WORKSPACE:/workspace" -w /workspace ubuntu:22.04 bash -s <<'EOF'
+        set -e -o pipefail
+        apt-get update -y
+        apt-get install -y build-essential git ocl-icd-opencl-dev
+        g++ --version
+
+        make -O -j "$(nproc)"
+        cd build-release
+        rm -f -- *.o
+        ./prpll -h
+        EOF
+    - uses: actions/upload-artifact@v7
+      with:
+        name: PRPLL-NTT_linux_x86_opencl
+        path: |
+          README.*
+          LICENSE
+          tools/
+          build-release/*
+
+  Linux-CUDA:
+    name: Linux CUDA
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - cuda: '13.2.1'
+          container: 'ubuntu24.04'
+        - cuda: '12.9.2'
+          container: 'ubuntu24.04'
+        - cuda: '11.8.0'
+          container: 'ubuntu22.04'
+        # - cuda: '10.2'
+        #   container: 'ubuntu18.04'
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+    - name: Script
+      run: |
+        docker run --rm -i -v "$GITHUB_WORKSPACE:/workspace" -w /workspace "nvcr.io/nvidia/cuda:${{ matrix.cuda }}-devel-${{ matrix.container }}" bash -s <<'EOF'
+        set -e -o pipefail
+        apt-get update -y
+        apt-get install -y build-essential git
+        g++ --version
+
+        make CUDA=1 ${{ matrix.cuda != '10.2' && 'CUDA_STATIC=1' || '' }} -O -j "$(nproc)"
+        cd build-cuda
+        rm -f -- *.o
+        if [[ "${{ matrix.cuda }}" == "10.2" ]]; then
+          cp /usr/local/cuda/lib64/libnvrtc.so.10.2 /usr/local/cuda/lib64/libnvrtc-builtins.so.10.2 .
+        fi
+        # ./prpll -h
+        EOF
+    - uses: actions/upload-artifact@v7
+      with:
+        name: PRPLL-NTT_linux_x86_cuda_${{ matrix.cuda }}
+        path: |
+          README.*
+          LICENSE
+          tools/
+          build-cuda/*
+
+  Windows-OpenCL:
+    name: Windows OpenCL
+
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+    - uses: step-security/msvc-dev-cmd@v1
+    - name: Install OpenCL
+      run: |
+        vcpkg install opencl
+    - name: Before Script
+      shell: bash
+      run: |
+        bash genbundle.sh src/cuda/*.cuh src/cl/*.cl > src/bundle.cpp
+        printf '"%s"\n' "$(basename "$(git describe --tags --long --always)")" > src/version.inc
+    - name: Script
+      run: |
+        msbuild PRPLL.sln /m /p:Configuration=OpenCL-Release /p:OpenCLRoot=C:\vcpkg\installed\x64-windows
+        cd build-msvc\OpenCL\Release\
+        & .\prpll -h
+    - uses: actions/upload-artifact@v7
+      with:
+        name: PRPLL-NTT_win_x86_opencl
+        path: |
+          README.*
+          LICENSE
+          tools/
+          build-msvc/OpenCL/Release/*
+
+  Windows-CUDA:
+    name: Windows CUDA
+
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        cuda: ['13.2.1', '12.9.2', '11.8.0', '10.2.89']
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+    - uses: step-security/msvc-dev-cmd@v1
+    - name: Install CUDA Toolkit
+      uses: N-Storm/cuda-toolkit@v0.2.34
+      with:
+        cuda: ${{ matrix.cuda }}
+    - name: Before Script
+      shell: bash
+      run: |
+        bash genbundle.sh src/cuda/*.cuh src/cl/*.cl > src/bundle.cpp
+        printf '"%s"\n' "$(basename "$(git describe --tags --long --always)")" > src/version.inc
+    - name: Script
+      run: |
+        msbuild PRPLL.sln /m /p:Configuration=CUDA-${{ matrix.cuda != '10.2.89' && 'Release' || 'Release-non-static' }}
+        cd build-msvc\CUDA\Release*\
+        if ("${{ matrix.cuda }}" -eq "10.2.89") {
+          Copy-Item "$env:CUDA_PATH\bin\nvrtc64_102_0.dll", "$env:CUDA_PATH\bin\nvrtc-builtins64_102.dll" .
+        }
+        # & .\prpll -h
+    - uses: actions/upload-artifact@v7
+      with:
+        name: PRPLL-NTT_win_x86_cuda_${{ matrix.cuda }}
+        path: |
+          README.*
+          LICENSE
+          tools/
+          build-msvc/CUDA/Release*/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/upload-artifact@v7
       if: always()
       with:
-        name: ${{ matrix.os }}_${{ endsWith(matrix.os, '-arm') && 'arm' || 'x86' }}_${{ matrix.cxx }}_prpll
+        name: ${{ matrix.os }}_${{ endsWith(matrix.os, '-arm') && 'arm' || 'x86' }}_${{ matrix.cxx }}_opencl_prpll
         path: build-debug/
 
   Linux-CUDA:
@@ -161,11 +161,12 @@ jobs:
       shell: bash
       run: |
         bash genbundle.sh src/cuda/*.cuh src/cl/*.cl > src/bundle.cpp
-        printf '"%s"\n' "$(basename "$(git describe --tags --long --always --match 'v/prpll/*')")" > src/version.inc
+        printf '"%s"\n' "$(basename "$(git describe --tags --long --always)")" > src/version.inc
     - name: Script
       run: |
         msbuild PRPLL.sln /m /p:Configuration=OpenCL-Debug /p:OpenCLRoot=C:\vcpkg\installed\x64-windows
-        & .\build-msvc\OpenCL\Debug\prpll.exe -h
+        cd build-msvc\OpenCL\Debug\
+        & .\prpll -h
     - uses: actions/upload-artifact@v7
       if: always()
       with:
@@ -185,10 +186,12 @@ jobs:
       shell: bash
       run: |
         bash genbundle.sh src/cuda/*.cuh src/cl/*.cl > src/bundle.cpp
-        printf '"%s"\n' "$(basename "$(git describe --tags --long --always --match 'v/prpll/*')")" > src/version.inc
+        printf '"%s"\n' "$(basename "$(git describe --tags --long --always)")" > src/version.inc
     - name: Script
       run: |
         msbuild PRPLL.sln /m /p:Configuration=CUDA-Debug
+        # cd build-msvc\CUDA\Debug\
+        # & .\prpll -h
     - uses: actions/upload-artifact@v7
       if: always()
       with:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,11 @@ ifeq ($(CUDA), 1)
  CUDASRCS1 = clwrap_cuda.cpp cudawrap.cpp
  CUDAFLAGS = -DCUDA_BACKEND -Isrc/cuda -I/usr/local/cuda/include
  CUDAOBJS = $(CUDASRCS1:%.cpp=$(BIN)/%.o)
- OPENCL_LIBS = -L/usr/local/cuda/lib64 -lcuda -lnvrtc
+ ifeq ($(CUDA_STATIC), 1)
+  OPENCL_LIBS = -L/usr/local/cuda/lib64 -Wl,--start-group -lnvrtc_static -lnvrtc-builtins_static -lnvptxcompiler_static -Wl,--end-group -lcuda
+ else
+  OPENCL_LIBS = -L/usr/local/cuda/lib64 -lnvrtc -lcuda
+ endif
 else
  BIN=build-release
  CUDAFLAGS =

--- a/PRPLL.vcxproj
+++ b/PRPLL.vcxproj
@@ -158,6 +158,14 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/SUBSYSTEM:CONSOLE,6.01 %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='OpenCL-Debug'">
     <Link>
       <AdditionalLibraryDirectories>$(OpenCLRoot)\debug\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -186,7 +194,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='CUDA-Release'">
     <Link>
-      <AdditionalDependencies>cuda.lib;nvrtc_static.lib;nvrtc-builtins_static.lib;nvptxcompiler_static.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cuda.lib;nvrtc_static.lib;nvrtc-builtins_static.lib;nvptxcompiler_static.lib;User32.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/cuda/clwrap_cuda.cpp
+++ b/src/cuda/clwrap_cuda.cpp
@@ -1136,6 +1136,7 @@ void cudaSetL1Config(int x) {
 // Computes the minimum address span covering all buffers, then sets one access policy
 // window with hitRatio sized so that only the actual buffer bytes get persisting treatment,
 // not the gaps between non-contiguous allocations.
+#if CUDA_VERSION >= 11000
 [[maybe_unused]] static void cudaSetL2Persistent(cl_command_queue q, const std::vector<cl_mem>& buffers) {
   if (!q) return;
 
@@ -1188,6 +1189,7 @@ void cudaSetL1Config(int x) {
             buffers.size());
   }
 }
+#endif
 
 
 // OpenCL-like extensions invented to provide a clean interface to some nVidia CUDA features
@@ -1213,8 +1215,10 @@ int clGraphEndRecording(cl_command_queue q, cl_graph* graph) {
   CUresult r = cuStreamEndCapture(q->stream, &g->graph);
 #if CUDA_VERSION >= 12000
   if (r == CUDA_SUCCESS) r = cuGraphInstantiate(&g->graphExec, g->graph, 0);
-#else
+#elif CUDA_VERSION >= 11040
   if (r == CUDA_SUCCESS) r = cuGraphInstantiateWithFlags(&g->graphExec, g->graph, 0);
+#else
+  if (r == CUDA_SUCCESS) r = cuGraphInstantiate(&g->graphExec, g->graph, nullptr, nullptr, 0);
 #endif
   *graph = g;
   return r == CUDA_SUCCESS ? CL_SUCCESS : CL_OUT_OF_RESOURCES;


### PR DESCRIPTION
* Added CD workflow to build release executables
  * Linux:
    * OpenCL
    * CUDA 13.2, 12.9 and 11.8
  * Windows:
    * OpenCL
    * CUDA 13.2, 12.9, 11.8 and 10.2
* Added `CUDA_STATIC` flag to the Makefile, to statically link CUDA
* Fixed CUDA 10 support