### PR TITLE
Updated CD workflow, Makefile and MSVC project file

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,25 +18,28 @@ jobs:
         fetch-tags: true
     - name: Script
       run: |
-        docker run --rm -i -v "$GITHUB_WORKSPACE:/workspace" -w /workspace ubuntu:22.04 bash -s <<'EOF'
+        docker run --rm -i -v "$GITHUB_WORKSPACE:/workspace" -w /workspace centos:7 bash -s <<'EOF'
         set -e -o pipefail
-        apt-get update -y
-        apt-get install -y build-essential git ocl-icd-opencl-dev
-        g++ --version
+        sed -i -e '/^mirrorlist/d;/^#baseurl=/{s,^#,,;s,/mirror,/vault,;}' /etc/yum.repos.d/CentOS*.repo
+        # yum update -y
+        yum install -y centos-release-scl epel-release
+        sed -i -e '/^mirrorlist/d;/^# *baseurl=/{s,^# *,,;s,/mirror,/vault,;}' /etc/yum.repos.d/CentOS*.repo
+        yum install -y devtoolset-11-gcc-c++ devtoolset-11-libstdc++-static make git ocl-icd-devel
 
-        make -O -j "$(nproc)"
+        source /opt/rh/devtoolset-11/enable
+        g++ --version
+        ldd --version
+
+        make STATIC_RUNTIME=1 -j "$(nproc)"
+        cp -vr README.* LICENSE tools/ build-release/
         cd build-release
         rm -f -- *.o
         ./prpll -h
         EOF
     - uses: actions/upload-artifact@v7
       with:
-        name: PRPLL-NTT_linux_x86_opencl
-        path: |
-          README.*
-          LICENSE
-          tools/
-          build-release/*
+        name: PRPLL-NTT_linux_x64_opencl
+        path: build-release/*
 
   Linux-CUDA:
     name: Linux CUDA
@@ -46,13 +49,13 @@ jobs:
       matrix:
         include:
         - cuda: '13.2.1'
-          container: 'ubuntu24.04'
+          container: 'rockylinux8'
         - cuda: '12.9.2'
-          container: 'ubuntu24.04'
+          container: 'rockylinux8'
         - cuda: '11.8.0'
-          container: 'ubuntu22.04'
-        # - cuda: '10.2'
-        #   container: 'ubuntu18.04'
+          container: 'centos7'
+        - cuda: '10.2'
+          container: 'centos7'
       fail-fast: false
     steps:
     - uses: actions/checkout@v7
@@ -63,26 +66,35 @@ jobs:
       run: |
         docker run --rm -i -v "$GITHUB_WORKSPACE:/workspace" -w /workspace "nvcr.io/nvidia/cuda:${{ matrix.cuda }}-devel-${{ matrix.container }}" bash -s <<'EOF'
         set -e -o pipefail
-        apt-get update -y
-        apt-get install -y build-essential git
-        g++ --version
+        if [[ "${{ matrix.container }}" == centos* ]]; then
+          sed -i -e '/^mirrorlist/d;/^#baseurl=/{s,^#,,;s,/mirror,/vault,;}' /etc/yum.repos.d/CentOS*.repo
+          # yum update -y
+          yum install -y centos-release-scl epel-release
+          sed -i -e '/^mirrorlist/d;/^# *baseurl=/{s,^# *,,;s,/mirror,/vault,;}' /etc/yum.repos.d/CentOS*.repo
+          yum install -y devtoolset-11-gcc-c++ devtoolset-11-libstdc++-static make git
+          source /opt/rh/devtoolset-11/enable
+        else
+          # dnf update -y
+          dnf install -y gcc-toolset-11-gcc-c++ make git
+          source /opt/rh/gcc-toolset-11/enable
+        fi
 
-        make CUDA=1 ${{ matrix.cuda != '10.2' && 'CUDA_STATIC=1' || '' }} -O -j "$(nproc)"
+        g++ --version
+        ldd --version
+
+        make CUDA=1 STATIC_RUNTIME=1 STATIC_CUDA=${{ matrix.cuda != '10.2' && '1' || '0' }} -j "$(nproc)"
+        cp -vr README.* LICENSE tools/ build-cuda/
         cd build-cuda
         rm -f -- *.o
         if [[ "${{ matrix.cuda }}" == "10.2" ]]; then
-          cp /usr/local/cuda/lib64/libnvrtc.so.10.2 /usr/local/cuda/lib64/libnvrtc-builtins.so.10.2 .
+          cp -v /usr/local/cuda/lib64/{libnvrtc.so.10.2,libnvrtc-builtins.so.10.2} .
         fi
         # ./prpll -h
         EOF
     - uses: actions/upload-artifact@v7
       with:
-        name: PRPLL-NTT_linux_x86_cuda_${{ matrix.cuda }}
-        path: |
-          README.*
-          LICENSE
-          tools/
-          build-cuda/*
+        name: PRPLL-NTT_linux_x64_cuda_${{ matrix.cuda }}
+        path: build-cuda/*
 
   Windows-OpenCL:
     name: Windows OpenCL
@@ -104,17 +116,14 @@ jobs:
         printf '"%s"\n' "$(basename "$(git describe --tags --long --always)")" > src/version.inc
     - name: Script
       run: |
-        msbuild PRPLL.sln /m /p:Configuration=OpenCL-Release /p:OpenCLRoot=C:\vcpkg\installed\x64-windows
+        msbuild PRPLL.sln /m /p:Configuration=OpenCL-Release /p:StaticRuntime=true /p:OpenCLRoot=C:\vcpkg\installed\x64-windows
+        Copy-Item -Recurse README.*, LICENSE, tools\ build-msvc\OpenCL\Release\
         cd build-msvc\OpenCL\Release\
         & .\prpll -h
     - uses: actions/upload-artifact@v7
       with:
-        name: PRPLL-NTT_win_x86_opencl
-        path: |
-          README.*
-          LICENSE
-          tools/
-          build-msvc/OpenCL/Release/*
+        name: PRPLL-NTT_win_x64_opencl
+        path: build-msvc/OpenCL/Release/*
 
   Windows-CUDA:
     name: Windows CUDA
@@ -141,17 +150,14 @@ jobs:
         printf '"%s"\n' "$(basename "$(git describe --tags --long --always)")" > src/version.inc
     - name: Script
       run: |
-        msbuild PRPLL.sln /m /p:Configuration=CUDA-${{ matrix.cuda != '10.2.89' && 'Release' || 'Release-non-static' }}
-        cd build-msvc\CUDA\Release*\
+        msbuild PRPLL.sln /m /p:Configuration=CUDA-Release /p:StaticRuntime=true /p:StaticCUDA=${{ matrix.cuda != '10.2.89' && 'true' || 'false' }}
+        Copy-Item -Recurse README.*, LICENSE, tools\ build-msvc\CUDA\Release\
+        cd build-msvc\CUDA\Release\
         if ("${{ matrix.cuda }}" -eq "10.2.89") {
           Copy-Item "$env:CUDA_PATH\bin\nvrtc64_102_0.dll", "$env:CUDA_PATH\bin\nvrtc-builtins64_102.dll" .
         }
         # & .\prpll -h
     - uses: actions/upload-artifact@v7
       with:
-        name: PRPLL-NTT_win_x86_cuda_${{ matrix.cuda }}
-        path: |
-          README.*
-          LICENSE
-          tools/
-          build-msvc/CUDA/Release*/*
+        name: PRPLL-NTT_win_x64_cuda_${{ matrix.cuda }}
+        path: build-msvc/CUDA/Release/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron:  '0 0 1 * *'
+    - cron: '0 0 1 * *'
 
 jobs:
   Linux-OpenCL:
@@ -48,9 +48,6 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         cxx: [g++, clang++]
-        exclude:
-        - os: ubuntu-22.04-arm
-          cxx: clang++
       fail-fast: false
     env:
       CXX: ${{ matrix.cxx }}
@@ -133,7 +130,7 @@ jobs:
     - name: Install Clang
       if: ${{ matrix.cxx == 'clang++' }}
       run: |
-        pacman -S --noconfirm mingw-w64-x86_64-clang
+        pacman -S --noconfirm "${env:PACKAGE_PREFIX}clang"
         & $env:CXX --version
     - name: Script
       run: |
@@ -204,7 +201,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-15-intel, macos-latest]
+        os: [macos-26-intel, macos-latest]
       fail-fast: false
     env:
       CXX: g++-15

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@
 
 # On Windows invoke with "make exe" or "make all"
 
+DEBUG = 0
+CUDA = 0
+STATIC_RUNTIME = 0
+STATIC_CUDA = 0
+
 # Uncomment below as desired to set a particular compiler or force a debug build:
 # CXX = g++-12
 # DEBUG = 1
@@ -12,22 +17,17 @@
 
 HOST_OS = $(shell uname -s)
 
-ifeq ($(HOST_OS), Darwin)
-# Real GCC (not clang), needed for 128-bit floats and std::filesystem::path
-CXX ?= g++-15
-else
 CXX ?= g++
-endif
 
 ifeq ($(CUDA), 1)
  BIN=build-cuda
  CUDASRCS1 = clwrap_cuda.cpp cudawrap.cpp
  CUDAFLAGS = -DCUDA_BACKEND -Isrc/cuda -I/usr/local/cuda/include
  CUDAOBJS = $(CUDASRCS1:%.cpp=$(BIN)/%.o)
- ifeq ($(CUDA_STATIC), 1)
-  OPENCL_LIBS = -L/usr/local/cuda/lib64 -Wl,--start-group -lnvrtc_static -lnvrtc-builtins_static -lnvptxcompiler_static -Wl,--end-group -lcuda
+ ifeq ($(STATIC_CUDA), 1)
+  OPENCL_LIBS = -L/usr/local/cuda/lib64 -Wl,--start-group -lnvrtc_static -lnvrtc-builtins_static -lnvptxcompiler_static -Wl,--end-group -lcuda -lpthread -ldl
  else
-  OPENCL_LIBS = -L/usr/local/cuda/lib64 -lnvrtc -lcuda
+  OPENCL_LIBS = -L/usr/local/cuda/lib64 -Wl,-rpath,'$$ORIGIN' -lnvrtc -lcuda -lpthread
  endif
 else
  BIN=build-release
@@ -36,15 +36,24 @@ else
  ifeq ($(HOST_OS), Darwin)
   OPENCL_LIBS = -framework OpenCL
  else
-  OPENCL_LIBS = -lOpenCL
+  OPENCL_LIBS = -lOpenCL -lpthread
  endif
 endif
 
-ifneq ($(findstring MINGW, $(HOST_OS)), MINGW)
- COMMON_FLAGS = -Wall $(CUDAFLAGS) -std=c++20 -static-libstdc++ -static-libgcc
-else
+COMMON_FLAGS = -Wall -Wextra $(CUDAFLAGS) -std=c++20
+
+ifeq ($(STATIC_RUNTIME),1)
+ LDFLAGS += -static-libstdc++ -static-libgcc
+
+ ifeq ($(findstring MINGW, $(HOST_OS)), MINGW)
 # For mingw-64 use this:
- COMMON_FLAGS = -Wall $(CUDAFLAGS) -std=c++20 -static-libstdc++ -static-libgcc -static
+  LDFLAGS += -static
+ endif
+endif
+
+ifeq ($(findstring MINGW, $(HOST_OS)), MINGW)
+ CPPFLAGS += -DWINVER=0x0601 -D_WIN32_WINNT=0x0601
+ LDFLAGS += -Wl,--subsystem,console:6.01
 endif
 # -fext-numeric-literals
 
@@ -52,12 +61,10 @@ ifeq ($(DEBUG), 1)
 
 BIN=build-debug
 CXXFLAGS = -g -Og $(COMMON_FLAGS)
-STRIP=
 
 else
 
-CXXFLAGS = -O3 -DNDEBUG $(COMMON_FLAGS)
-STRIP=-s
+CXXFLAGS = -O3 -flto -DNDEBUG $(COMMON_FLAGS)
 
 endif
 
@@ -81,14 +88,14 @@ prpll: $(BIN)/prpll
 amd: $(BIN)/prpll-amd
 
 #$(BIN)/test: $(BIN)/test.o
-#	$(CXX) $(CXXFLAGS) -o $@ $< $(LIBPATH) ${STRIP}
+#	$(CXX) $(CXXFLAGS) -o $@ $< $(LIBPATH)
 
 $(BIN)/prpll: ${OBJS}
-	$(CXX) $(CXXFLAGS) -o $@ ${OBJS} $(LIBPATH) $(OPENCL_LIBS) ${STRIP}
+	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o $@ ${OBJS} $(LIBPATH) $(OPENCL_LIBS)
 
 # Instead of linking with libOpenCL, link with libamdocl64
 $(BIN)/prpll-amd: ${OBJS}
-	$(CXX) $(CXXFLAGS) -o $@ ${OBJS} $(LIBPATH) -lamdocl64 -L/opt/rocm/lib ${STRIP}
+	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o $@ ${OBJS} $(LIBPATH) -lamdocl64 -L/opt/rocm/lib
 
 clean:
 	rm -rf build-debug build-release build-cuda

--- a/PRPLL.sln
+++ b/PRPLL.sln
@@ -10,7 +10,6 @@ Global
 		OpenCL-Release|x64 = OpenCL-Release|x64
 		CUDA-Debug|x64 = CUDA-Debug|x64
 		CUDA-Release|x64 = CUDA-Release|x64
-		CUDA-Release-non-static|x64 = CUDA-Release-non-static|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2B3F9C8E-3384-0407-D9E1-D3E86AA8823A}.OpenCL-Debug|x64.ActiveCfg = OpenCL-Debug|x64
@@ -21,8 +20,6 @@ Global
 		{2B3F9C8E-3384-0407-D9E1-D3E86AA8823A}.CUDA-Debug|x64.Build.0 = CUDA-Debug|x64
 		{2B3F9C8E-3384-0407-D9E1-D3E86AA8823A}.CUDA-Release|x64.ActiveCfg = CUDA-Release|x64
 		{2B3F9C8E-3384-0407-D9E1-D3E86AA8823A}.CUDA-Release|x64.Build.0 = CUDA-Release|x64
-		{2B3F9C8E-3384-0407-D9E1-D3E86AA8823A}.CUDA-Release-non-static|x64.ActiveCfg = CUDA-Release-non-static|x64
-		{2B3F9C8E-3384-0407-D9E1-D3E86AA8823A}.CUDA-Release-non-static|x64.Build.0 = CUDA-Release-non-static|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PRPLL.vcxproj
+++ b/PRPLL.vcxproj
@@ -17,10 +17,6 @@
       <Configuration>CUDA-Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="CUDA-Release-non-static|x64">
-      <Configuration>CUDA-Release-non-static</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include=".\src\AllocTrac.cpp" />
@@ -79,7 +75,7 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='OpenCL-Release' Or '$(Configuration)'=='CUDA-Release' Or '$(Configuration)'=='CUDA-Release-non-static'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)'=='OpenCL-Release' Or '$(Configuration)'=='CUDA-Release'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -92,7 +88,10 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Label="UserMacros">
+    <StaticRuntime Condition="'$(StaticRuntime)'==''">true</StaticRuntime>
+    <StaticCUDA Condition="'$(StaticCUDA)'==''">false</StaticCUDA>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='OpenCL-Debug'">
     <OutDir>$(ProjectDir)build-msvc\OpenCL\Debug\</OutDir>
     <IntDir>$(ProjectDir)build-msvc\obj\OpenCL\Debug\</IntDir>
@@ -115,14 +114,9 @@
     <IntDir>$(ProjectDir)build-msvc\obj\CUDA\Release\</IntDir>
     <TargetName>prpll</TargetName>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='CUDA-Release-non-static'">
-    <OutDir>$(ProjectDir)build-msvc\CUDA\Release-non-static\</OutDir>
-    <IntDir>$(ProjectDir)build-msvc\obj\CUDA\Release-non-static\</IntDir>
-    <TargetName>prpll</TargetName>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PreprocessorDefinitions>WIN32;WIN64;_CONSOLE;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <ExceptionHandling>Sync</ExceptionHandling>
@@ -136,7 +130,8 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(StaticRuntime)'=='true'">MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(StaticRuntime)'!='true'">MultiThreadedDebugDLL</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
     </ClCompile>
@@ -144,13 +139,14 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='OpenCL-Release' Or '$(Configuration)'=='CUDA-Release' Or '$(Configuration)'=='CUDA-Release-non-static'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='OpenCL-Release' Or '$(Configuration)'=='CUDA-Release'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(StaticRuntime)'=='true'">MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(StaticRuntime)'!='true'">MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -178,7 +174,7 @@
       <AdditionalDependencies>OpenCL.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='CUDA-Debug' Or '$(Configuration)'=='CUDA-Release' Or '$(Configuration)'=='CUDA-Release-non-static'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='CUDA-Debug' Or '$(Configuration)'=='CUDA-Release'">
     <ClCompile>
       <PreprocessorDefinitions>CUDA_BACKEND;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)\src\cuda;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -187,12 +183,12 @@
       <AdditionalLibraryDirectories>$(CUDA_PATH)\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='CUDA-Debug' Or '$(Configuration)'=='CUDA-Release-non-static'">
+  <ItemDefinitionGroup Condition="('$(Configuration)'=='CUDA-Debug' Or '$(Configuration)'=='CUDA-Release') And '$(StaticCUDA)'!='true'">
     <Link>
       <AdditionalDependencies>cuda.lib;nvrtc.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='CUDA-Release'">
+  <ItemDefinitionGroup Condition="('$(Configuration)'=='CUDA-Debug' Or '$(Configuration)'=='CUDA-Release') And '$(StaticCUDA)'=='true'">
     <Link>
       <AdditionalDependencies>cuda.lib;nvrtc_static.lib;nvrtc-builtins_static.lib;nvptxcompiler_static.lib;User32.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>


### PR DESCRIPTION
* Updated CD workflow based on feedback
* Changed CD workflow to build the Linux executables on CentOS and Rocky Linux instead of Ubuntu
  * This lowered the required glibc version from 2.35 to 2.17.
  * This also allowed adding a Linux build with CUDA 10.2.
* Updated Makefile
  * Added missing linker flags. Enabled LTO for consistency with MSVC.
  * Added `STATIC_RUNTIME` flag to statically link the C++ runtime. Defaults a non-static C++ runtime.
* Updated MSVC project file
  * Replaced "CUDA-Release-non-static" configuration with separate `StaticCUDA` flag to statically link the CUDA runtime. Defaults to non-static CUDA runtime.
  * Added `StaticRuntime` flag to statically link the C++ runtime. Defaults to a static C++ runtime.
* Changed the CI to build on the newer macOS 26 Intel runner