### PR TITLE
OpenCL: rename the Z61 fma() overload so it stops hiding the builtin

### DIFF
--- a/src/cl/math.cl
+++ b/src/cl/math.cl
@@ -962,7 +962,12 @@ Z61 OVERLOAD weakMulAdd(Z61 a, Z61 b, u128 c, const u32 a_m61_count, const u32 b
 
 Z61 OVERLOAD mul(Z61 a, Z61 b) { return modM61(weakMul(a, b, 2, 2)); }
 
-Z61 OVERLOAD fma(Z61 a, Z61 b, Z61 c) { return modM61(weakMulAdd(a, b, c, 2, 2)); }
+// Not named fma(): declaring a user overload of fma() hides the OpenCL builtin
+// fma(float,float,float), so in a build with both FFT_FP32 and NTT_GF61 the float call sites
+// (chainMul4() in fftbase.cl, for one) resolve to this overload instead, convert their float
+// arguments to ulong, and return ulong2 where float2 is expected. This overload has no call
+// sites, so the name is free to change.
+Z61 OVERLOAD fmaZ61(Z61 a, Z61 b, Z61 c) { return modM61(weakMulAdd(a, b, c, 2, 2)); }
 
 // Multiply by 2
 Z61 OVERLOAD mul2(Z61 a) { return add(a, a); }


### PR DESCRIPTION
Every FP32-bearing transform type fails to compile under ROCm. This is a one-line fix for the
first of the three errors involved; the other two are a regression from 4dd32c9 and are only
reported below, not touched here.

## The fix

`math.cl` declares an overloadable `fma(Z61, Z61, Z61)`. Declaring a user overload named `fma()`
removes the OpenCL builtin `fma(float,float,float)` from the overload set, so in a build with both
`FFT_FP32` and `NTT_GF61` the float call sites resolve to the Z61 overload, convert their float
arguments to `ulong`, and return `ulong2` where `float2` is expected:

```
fftbase.cl:1212:8: error: assigning to '__private F2' (aka '__private float2')
                   from incompatible type 'ulong2' (vector of 2 'ulong' values)
 1212 |   base = U2(fma(a, -w.y, w.x), fma(a, w.x, -w.y));
```

That takes out `FFT3261`, `FFT3231` and `FFT323161`. It also happens to be what PRPLL picks by
default when there is no `tune.txt`, so a fresh build does not start at all.

The overload has no call sites anywhere in `src/cl`, so renaming it to `fmaZ61` costs nothing.

Same root cause as #2, which was opened in March and closed by its author without review.

### Reproducing

```
prpll -prp 104000021 -iters 10000     # selects 4M 4:1K:8:256
```

| commit | date | compile errors |
|---|---|---|
| 1ef7716 | 2026-08-10 | 1 |
| 14e2160 | 2026-08-14 | 1 |
| 4dd32c9 | 2026-08-15 | 3 |

With this patch on 4dd32c9: 2 remain, both from the section below.

### That the FP32 path works once this is fixed

With this rename applied to 1ef7716 (before the regression), `FFT323161` runs correctly. I used it
to complete a PRP double-check of M92204027 at `4:512:4:512`, `gerbicz:0`; the residue matched the
2020 first-time test exactly, and the proof was accepted by PrimeNet.

## Not fixed here: 4dd32c9 broke the combined types a second way

The two remaining errors are new in 4dd32c9:

```
fftbase.cl:1638:5: error: call to 'shufl' is ambiguous
 1638 |     shufl(lds, u, s, numWG, lowMe);
      |     ^~~~~
fftbase.cl:37:36: note: candidate function
   37 | void __attribute__((overloadable)) shufl(local GF61 *lds2, GF61 *u, u32 f, u32 numWG, u32 lowMe) {
fftbase.cl:378:36: note: candidate function
  378 | void __attribute__((overloadable)) shufl(local GF31 *lds2, GF31 *u, u32 f, u32 numWG, u32 lowMe) {

fftp.cl:575:3: error: call to 'writeCarryFusedLine' is ambiguous
  575 |   writeCarryFusedLine(uF2, outF2, g, me);
      |   ^~~~~~~~~~~~~~~~~~~
middle.cl:58:36: note: candidate function
   58 | void __attribute__((overloadable)) writeCarryFusedLine(GF61 *u, global GF61 * restrict out, u32 line, u32 me) {
middle.cl:384:36: note: candidate function
  384 | void __attribute__((overloadable)) writeCarryFusedLine(GF31 *u, global GF31 * restrict out, u32 line, u32 me) {
```

(Line numbers are as comgr reports them, one more than the file on disk. The candidates are
`shufl` declared with `T2_GF61` / `F2_GF31` at `fftbase.cl:36` and `:377`, and
`writeCarryFusedLine` with the same pair at `middle.cl:57` and `:383`, after macro expansion.)

The combo-datatype macros in `base.cl` assume the FP and NTT variants are mutually exclusive:

```c
#if FFT_FP32
#define F2_GF31 F2
#endif
#if NTT_GF31
#define F2_GF31 GF31
#endif
```

In `FFT3261` / `FFT3231` / `FFT323161` both are enabled at once, so the second definition wins and
the `F2` instantiation of `shufl()`, `writeCarryFusedLine()`, `read()` and `write()` is never
generated. Calling them with `F2*` then finds only the `GF61` (`ulong2`) and `GF31` (`uint2`)
candidates, and neither is an exact match. The compiler says as much:

```
base.cl:783:9: warning: 'F2_GF31' macro redefined [-Wmacro-redefined]
base.cl:778:9: note: previous definition is here
```

`T2_F2_GF31_GF61` is redefined three times in the same build for the same reason.

This is a preprocessor-level problem, so I would not expect it to be AMD-specific, and it is
probably just that the combined types have not been exercised since the refactor. I have not
attempted a fix because the right shape for it is a call about where the combo types are heading.

## Environment

- AMD Radeon Pro V620 (gfx1030), ROCm 7.14, OpenCL `3581.0 (HSA1.1,LC)`
- Ubuntu 24.04, kernel 6.17, g++ 13.3
- `FFT3161` and `FFT64` build and run fine throughout; only the FP32-bearing types are affected

## Disclosure

The diagnosis and this patch were produced with AI assistance (Claude). Everything asserted above
was checked on the hardware named: the errors, the per-commit bisect, the empty call-site search,
and the M92204027 double-check. The reproduction command is one line, so please verify rather than
take my word for any of it.