### PR TITLE
Fix wrong residue table after reducePower()

### DIFF
--- a/src/Proof.cpp
+++ b/src/Proof.cpp
@@ -142,8 +142,11 @@ ProofSet::ProofSet(u64 E, u32 power)
 
   fs::create_directories(proofPath(E));
 
-  vector<u64> spans;
-  for (u64 span = (E + 1) / 2; spans.size() < power; span = (span + 1) / 2) { spans.push_back(span); }
+  rebuildPoints();
+}
+
+void ProofSet::rebuildPoints() {
+  points.clear();
 
   points.push_back(0);
   u32 p;
@@ -169,6 +172,12 @@ ProofSet::ProofSet(u64 E, u32 power)
   for ([[maybe_unused]] u64 const p : points) {
     assert(p > E || isInPoints(E, power, p));
   }
+}
+
+void ProofSet::reducePower() {
+  assert(power > 0);
+  --power;
+  rebuildPoints();
 }
 
 bool ProofSet::isInPoints(u64 E, u32 power, u64 k) {

--- a/src/Proof.h
+++ b/src/Proof.h
@@ -59,6 +59,8 @@ public:
   
 private:  
   vector<u64> points;
+
+  void rebuildPoints();
   
   bool isValidTo(u64 limitK) const;
 
@@ -86,6 +88,6 @@ public:
   void save(u64 k, const Words& words) const { return save(E, power, k, words); }
   Words load(u64 k) const { return load(E, power, k); }
 
-  void reducePower() { power--; }
+  void reducePower();
   std::pair<Proof, vector<u64>> computeProof(Gpu *gpu) const;
 };


### PR DESCRIPTION
The point table was not being reset after reducing power due to a failed proof. This results in each subsequent proof also being invalid, even if the reduced-power proof would otherwise be valid baed on the remaining residues.