### PR TITLE
Try reduced power proof on CRCError

### DIFF
--- a/src/Gpu.cpp
+++ b/src/Gpu.cpp
@@ -2259,18 +2259,22 @@ fs::path Gpu::saveProof(const Args& args, ProofSet& proofSet) {
   bool problem_proof = false;
   for ( ; ; ) {
     for (int retry = 0; retry == 0 || (retry == 1 && !problem_proof); ++retry) {
-      auto [proof, hashes] = proofSet.computeProof(this);
-      fs::path const tmpFile = proof.file(args.proofToVerifyDir);
-      proof.save(tmpFile);
-            
-      fs::path proofFile = proof.file(args.proofResultDir);
+      try {
+        auto [proof, hashes] = proofSet.computeProof(this);
+        fs::path const tmpFile = proof.file(args.proofToVerifyDir);
+        proof.save(tmpFile);
 
-      bool const ok = Proof::load(tmpFile).verify(this, hashes);
-      log("Proof '%s' verification %s\n", tmpFile.string().c_str(), ok ? "OK" : "FAILED");
-      if (ok) {
-        fancyRename(tmpFile, proofFile);
-        log("Proof '%s' generated\n", proofFile.string().c_str());
-        return proofFile;
+        fs::path proofFile = proof.file(args.proofResultDir);
+
+        bool const ok = Proof::load(tmpFile).verify(this, hashes);
+        log("Proof '%s' verification %s\n", tmpFile.string().c_str(), ok ? "OK" : "FAILED");
+        if (ok) {
+          fancyRename(tmpFile, proofFile);
+          log("Proof '%s' generated\n", proofFile.string().c_str());
+          return proofFile;
+        }
+      } catch (const CRCError&) {
+        break;
       }
     }
     problem_proof = true;


### PR DESCRIPTION
Proof generation can fail in two different ways. If residue corruption happens in memory before CRC generation, then the proof will generate but fail validation. If residue corruption happens any time after CRC generation, `CRCError` is raised before a proof is even generated.

CRC errors correctly reduce proof power when loading saved state in `ProofSet::effectivePower`, but not in proof generation, where they currently crash the process. We should handle both validation failures and CRC errors during proof generation in the same way via power reduction.